### PR TITLE
check if SLOTS exists before checking for a specific slot

### DIFF
--- a/Loadable.svelte
+++ b/Loadable.svelte
@@ -66,7 +66,7 @@
 {:else if state === STATES.LOADING}
   <slot name="loading" />
 {:else if state === STATES.SUCCESS}
-  {#if SLOTS.success}
+  {#if SLOTS && SLOTS.success}
     <slot name="success" {component} />
   {:else}
     <svelte:component this={component} />


### PR DESCRIPTION
Code throws an error when svelte-loadable is used without slots