### PR TITLE
Pass non-Loadable properties to the loaded component

### DIFF
--- a/Loadable.svelte
+++ b/Loadable.svelte
@@ -76,6 +76,6 @@
   {#if slots && slots.success}
     <slot name="success" {component} props={$$props} />
   {:else}
-    <svelte:component this={component} />
+    <svelte:component this={component} {...componentProps} />
   {/if}
 {/if}


### PR DESCRIPTION
This PR attaches additional properties to the loaded component when not using a named slot. This allows patterns like this:

```svelte
<Router url="{url}">
  <MainLayout>
    <Route path="pages/:slug" let:params>
      <Loadable loader={() => import('./pages/Page.svelte')} slug={params.slug}>
        <div slot="loading">Loading...</div>
      </Loadable>
    </Route>
    <Route path="/">
      <Loadable loader={() => import('./home/Home.svelte')} />
    </Route>
  </MainLayout>
</Router>
```

```svelte
<script>
import { Pages } from '/imports/api/collections/pages'
import track from '/imports/utils/useTracker'

export let slug = ''

let page
let isReady
track(function () {
  isReady = Meteor.subscribe('page', slug).ready()
})
track(function () {
  page = Pages.findOne({ slug })
})
</script>

{#if !isReady}
  <div>Loading</div>
{/if}
{#if page}
  <div>{@html page.content}</div>
{/if}
```

This PR does apply the props differently from a previous patch on the slotted code path. That applies ALL $$props to the child component, including the loader and other Loadable config. This PR avoids that for non-slotted children. I wonder whether the slotted behavior should also only pass the leftover `componentProps` instead of passing everything?

It would also be nice if the two used the same signature, but it's not allowed to spread onto a slot...