### PR TITLE
Set delay default to 200, and add note in the readme

### DIFF
--- a/Loadable.svelte
+++ b/Loadable.svelte
@@ -9,7 +9,7 @@
     TIMEOUT: 4,
   })
 
-  export let delay = 0
+  export let delay = 200
   export let timeout = null
   export let loader = null
   export let component = null

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Just pass a `loader` method which return a async module import:
 
 ### Props
 
-- `loader`: a function which `import()` your component to the `<Loadable>` component;
-- `delay`: minimum delay in `msecs` for showing the `loading slot`;
+- `loader`: a function which `import()` your component to the `<Loadable>` component.
+- `delay`: minimum delay in `msecs` for showing the `loading slot`. Default: 200
 - `timeout`: time in `msecs` for showing the `timeout slot`.
 
 ### Slots


### PR DESCRIPTION
Set the loading delay to 200ms by default. This is in line with react-loadable and is a pretty good default.