### PR TITLE
Add the babel-plugin with configuration notes in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ By default, Svelte Loadable will dynamically load the specified loader (import s
 
 To set that up, you'll need to `register` the loader at definition time in a module script block, instead of passing the loader directly to the loadable component instance, then pass the resulting loader on to the loadable component. It looks like this (with `svelte-routing`).
 
-*NOTE:* A resolve function is necessary for most SSR solutions. The function must return an absolute path, which will be used for indexing, and for loading before hydration. The specific way to generate that may vary by platform. A babel plugin for Svelte Loadable to help generate that automatically is forthcoming.
+*NOTE:* A `resolve` function is necessary for the cache to keep track of its loaded assets, and for SSR solutions. The `resolve` function must return a resolved path, which will be used to keep track of loadables, and to facilitate loading before hydration in SSR solutions. A [babel plugin](#babel-plugin) is included for basic caching functionality.
 
 **App.svelte:**
 
@@ -114,6 +114,36 @@ Another advantage is that if the same module is registered in two different plac
 
 This comes with additional benefits and opportunities as well. There is now a `preloadAll` method, which can be used to proactively (and recursively) preload all the modules after the initial render of the application, if desired. That method can also be used server side to preload all the necessary components to pull off server side rendering (SSR).
 
+### babel plugin
+
+The Svelte Loadable babel plugin will automatically add the `resolve` method to your registered loaders, to cut down on manual configuration. Add the Svelte Loadable babel plugin to your plugins list in `.babelrc` or equivalent:
+
+**.babelrc or package.json**
+
+```json
+{
+  "plugins": [
+    "svelte-loadable/babel"
+  ]
+}
+```
+
+Once configured, you can skip adding the resolve method, and let the babel plugin do it for you:
+
+```html
+<script context="module">
+import { register } from 'svelte-loadable'
+
+// Loaders must be registered outside of the render tree.
+const PageLoader = register({
+  loader: () => import('./pages/Page.svelte')
+})
+const HomeLoader = register({
+  loader: () => import('./home/Home.svelte')
+})
+</script>
+```
+
 ### Additional Methods
 
 #### preloadAll()
@@ -129,7 +159,7 @@ preloadAll().then(() => {...});
 
 ### The 'svelte-loadable-capture' Context for SSR
 
-To facilitate the creation of SSR solutions, Svelte Loadable uses a context which can be set up by an SSR solution in a `LoadableProvider` using the string identifier 'svelte-loadable-capture'. Svelte Loadable expects the context to provide a method, to which it will pass the registered loader function. For an example implementation, check out [`npdev:svelte-loadable`](https://github.com/CaptainN/npdev-svelte-loadable) a Meteor SSR solution.
+To facilitate the creation of SSR solutions, Svelte Loadable uses a context which can be set up by an SSR solution in a `LoadableProvider` using the string identifier 'svelte-loadable-capture'. Svelte Loadable expects the context to provide a method, to which it will pass the registered loader function. For an example implementation, check out [`npdev:svelte-loadable`](https://github.com/CaptainN/npdev-svelte-loadable) a Meteor SSR solution built on top of Svelte Loadable. The [babel plugin](#babel-plugin) is also useful for SSR, and provides everything needed for basic runtime caching, and `npdev:svele-loadable`.
 
 ---
 

--- a/babel/LICENSE
+++ b/babel/LICENSE
@@ -1,0 +1,22 @@
+COPYRIGHT (c) 2017-present James Kyle <me@thejameskyle.com>
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/babel/index.js
+++ b/babel/index.js
@@ -1,0 +1,81 @@
+'use strict'
+exports.__esModule = true
+exports.default = function ({ types: t }) {
+  return {
+    visitor: {
+      ImportDeclaration (path) {
+        var source = path.node.source.value
+        if (!source.endsWith('svelte-loadable')) return
+
+        var specifier = path.get('specifiers').find(specifier => {
+          return (specifier.parent.source.value.endsWith('svelte-loadable') &&
+            specifier.node.local.name === 'register')
+        })
+
+        if (!specifier) return
+
+        var bindingName = specifier.node.local.name
+        var binding = path.scope.getBinding(bindingName)
+
+        binding.referencePaths.forEach(refPath => {
+          var callExpression = refPath.parentPath
+
+          if (
+            callExpression.isMemberExpression() &&
+            callExpression.node.computed === false &&
+            callExpression.get('property').isIdentifier({ name: 'Map' })
+          ) {
+            callExpression = callExpression.parentPath
+          }
+
+          if (!callExpression.isCallExpression()) return
+
+          var args = callExpression.get('arguments')
+          if (args.length !== 1) throw callExpression.error
+
+          var options = args[0]
+          if (!options.isObjectExpression()) return
+
+          var properties = options.get('properties')
+          var propertiesMap = {}
+
+          properties.forEach(property => {
+            var key = property.get('key')
+            propertiesMap[key.node.name] = property
+          })
+
+          if (propertiesMap.meteor) {
+            return
+          }
+
+          var loaderMethod = propertiesMap.loader.get('value')
+          var dynamicImport
+
+          loaderMethod.traverse({
+            Import (path) {
+              dynamicImport = path.parentPath
+            }
+          })
+
+          if (!dynamicImport) return
+
+          propertiesMap.loader.insertAfter(
+            t.objectProperty(
+              t.identifier('resolve'),
+              t.arrowFunctionExpression(
+                [],
+                t.callExpression(
+                  t.memberExpression(
+                    t.identifier('require'),
+                    t.identifier('resolve')
+                  ),
+                  [dynamicImport.get('arguments')[0].node]
+                )
+              )
+            )
+          )
+        })
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "prepublishOnly": "npm run release && npm run tag"
   },
   "files": [
-    "Loadable.svelte"
+    "Loadable.svelte",
+    "babel/**"
   ],
   "devDependencies": {
     "babel-eslint": "^10.0.1",


### PR DESCRIPTION
Thanks for merging all the stuff I've been throwing at you! I appreciate it. This should really be the last addition. The only other thing I'd like to add is maybe some porting notes for anyone who wants to pick up a port to WebPack. Other than that, this should be it!

This PR adds a babel plugin, which can be configured to automatically add the `resolve` method to registered loaders (less boilerplate - yay!). As explained in the readme:

### babel plugin

The Svelte Loadable babel plugin will automatically add the `resolve` method to your registered loaders, to cut down on manual configuration. Add the Svelte Loadable babel plugin to your plugins list in `.babelrc` or equivalent:

**.babelrc or package.json**

```json
{
  "plugins": [
    "svelte-loadable/babel"
  ]
}
```

Once configured, you can skip adding the resolve method, and let the babel plugin do it for you:

```html
<script context="module">
import { register } from 'svelte-loadable'

// Loaders must be registered outside of the render tree.
const PageLoader = register({
  loader: () => import('./pages/Page.svelte')
})
const HomeLoader = register({
  loader: () => import('./home/Home.svelte')
})
</script>
```