### PR TITLE
feat: add ability to unload component and optionally callback

### DIFF
--- a/Loadable.svelte
+++ b/Loadable.svelte
@@ -57,7 +57,7 @@
   export let delay = 200
   export let timeout = null
   export let loader = null
-  export let unload = false
+  export let unloadOnDestroy = false
   export let component = null
   export let error = null
 
@@ -127,11 +127,11 @@
   } else {
     onMount(() => {
       load()
-      if (unload && unload !== 'false') {
+      if (unloadOnDestroy && unloadOnDestroy !== 'false') {
         return () => {
           LOADED.delete(loader)
-          if (typeof unload === 'function') {
-            unload()
+          if (typeof unloadOnDestroy === 'function') {
+            unloadOnDestroy()
           }
         }
       }

--- a/Loadable.svelte
+++ b/Loadable.svelte
@@ -57,7 +57,7 @@
   export let delay = 200
   export let timeout = null
   export let loader = null
-  export let unloadOnDestroy = false
+  export let unloader = false
   export let component = null
   export let error = null
 
@@ -127,11 +127,11 @@
   } else {
     onMount(() => {
       load()
-      if (unloadOnDestroy && unloadOnDestroy !== 'false') {
+      if (unloader) {
         return () => {
           LOADED.delete(loader)
-          if (typeof unloadOnDestroy === 'function') {
-            unloadOnDestroy()
+          if (typeof unloader === 'function') {
+            unloader()
           }
         }
       }

--- a/Loadable.svelte
+++ b/Loadable.svelte
@@ -57,6 +57,7 @@
   export let delay = 200
   export let timeout = null
   export let loader = null
+  export let unload = false
   export let component = null
   export let error = null
 
@@ -124,7 +125,17 @@
     state = STATES.SUCCESS
     component = LOADED.get(loader)
   } else {
-    onMount(load)
+    onMount(() => {
+      load()
+      if (unload && unload !== 'false') {
+        return () => {
+          LOADED.delete(loader)
+          if (typeof unload === 'function') {
+            unload()
+          }
+        }
+      }
+    })
   }
 </script>
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,32 @@ Just pass a `loader` method which return a async module import:
 <Loadable loader={() => import('./AsyncComponent.svelte')} />
 ```
 
+Use `unload` to prevent Loadable from caching the component which will cause it to call `loader` each time the component is used.
+The example below is using SystemJS module loader which has the ability to 'unload' (delete) a loaded module.
+
+```html
+<script>
+  import Loadable from 'svelte-loadable'
+</script>
+
+<Loadable
+  loader={() => System.import('./AsyncComponent.svelte')}
+
+  <!-- use just unload (or unload=true) to ensure the component is not cached -->
+  <!-- unload -->
+
+  <!-- or use unload as a callback to ensure the component is not cached and
+       calls the callback immediatly after it is uncached -->
+  unload={() => System.delete(`${location.href}/AsyncComponent.svelte`)}
+/>
+```
+
 ### Props
 
 - `loader`: a function which `import()` your component to the `<Loadable>` component.
 - `delay`: minimum delay in `msecs` for showing the `loading slot`. Default: 200
 - `timeout`: time in `msecs` for showing the `timeout slot`.
+- `unload`: true to prevent the component from being reloaded or a function that will be called when Loadable is unmounted.
 
 Any other prop will be passed directly onto the rendered component if the `default` slot is defined:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Just pass a `loader` method which return a async module import:
 <Loadable loader={() => import('./AsyncComponent.svelte')} />
 ```
 
-Use `unloader` to prevent Loadable from caching the component which will cause it to call `loader` each time the component is used.
+Use `unloader` to prevent `Loadable` from caching the component which will cause it to call `loader` each time the component is used after being unmounted.
 
 ```html
 <script>

--- a/README.md
+++ b/README.md
@@ -14,24 +14,34 @@ Just pass a `loader` method which return a async module import:
 <Loadable loader={() => import('./AsyncComponent.svelte')} />
 ```
 
-Use `unloadOnDestroy` to prevent Loadable from caching the component which will cause it to call `loader` each time the component is used.
-The example below is using SystemJS module loader which has the ability to 'unloadOnDestroy' (delete) a loaded module.
+Use `unloader` to prevent Loadable from caching the component which will cause it to call `loader` each time the component is used.
 
 ```html
 <script>
   import Loadable from 'svelte-loadable'
+
+  // unloader callback
+  function unloader() {
+    // some code here
+  }
 </script>
 
+<!-- unloader as boolean -->
+<Loadable ... unloader />
+<Loadable ... unloader={true} />
+<Loadable ... unloader={someBooleanValue} />
+
+<!-- unloader as predefined function in script tag above -->
+<Loadable ... {unloader} />
+<!-- unloader as an inline function -->
+<Loadable ... unloader={() => { /* some code here */ }} />
+
+<!-- example using SystemJS Module Loader which has the ability to unload (delete) a previously loaded module -->
 <Loadable
   loader={() => System.import('./AsyncComponent.svelte')}
-
-  <!-- use just unloadOnDestroy (or unloadOnDestroy=true) to ensure the component is not cached -->
-  <!-- unloadOnDestroy -->
-
-  <!-- or use unloadOnDestroy as a callback to ensure the component is not cached and
-       calls the callback immediatly after it is uncached -->
-  unloadOnDestroy={() => System.delete(`${location.href}/AsyncComponent.svelte`)}
+  unloader={() => System.delete(System.resolve('./AsyncComponent.svelte'))}
 />
+
 ```
 
 ### Props
@@ -39,7 +49,7 @@ The example below is using SystemJS module loader which has the ability to 'unlo
 - `loader`: a function which `import()` your component to the `<Loadable>` component.
 - `delay`: minimum delay in `msecs` for showing the `loading slot`. Default: 200
 - `timeout`: time in `msecs` for showing the `timeout slot`.
-- `unloadOnDestroy`: true to prevent the component from being cached or a function which will also prevent the component from being cached and will be called immediatly after it is uncached.
+- `unloader`: true to prevent the component from being cached or a function which will also prevent the component from being cached and will be called immediatly after it is uncached.
 
 Any other prop will be passed directly onto the rendered component if the `default` slot is defined:
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The example below is using SystemJS module loader which has the ability to 'unlo
 - `loader`: a function which `import()` your component to the `<Loadable>` component.
 - `delay`: minimum delay in `msecs` for showing the `loading slot`. Default: 200
 - `timeout`: time in `msecs` for showing the `timeout slot`.
-- `unload`: true to prevent the component from being reloaded or a function that will be called when Loadable is unmounted.
+- `unload`: true to prevent the component from being cached or a function which will also prevent the component from being cached and will be called immediatly after it is uncached.
 
 Any other prop will be passed directly onto the rendered component if the `default` slot is defined:
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Just pass a `loader` method which return a async module import:
 <Loadable loader={() => import('./AsyncComponent.svelte')} />
 ```
 
-Use `unload` to prevent Loadable from caching the component which will cause it to call `loader` each time the component is used.
-The example below is using SystemJS module loader which has the ability to 'unload' (delete) a loaded module.
+Use `unloadOnDestroy` to prevent Loadable from caching the component which will cause it to call `loader` each time the component is used.
+The example below is using SystemJS module loader which has the ability to 'unloadOnDestroy' (delete) a loaded module.
 
 ```html
 <script>
@@ -25,12 +25,12 @@ The example below is using SystemJS module loader which has the ability to 'unlo
 <Loadable
   loader={() => System.import('./AsyncComponent.svelte')}
 
-  <!-- use just unload (or unload=true) to ensure the component is not cached -->
-  <!-- unload -->
+  <!-- use just unloadOnDestroy (or unloadOnDestroy=true) to ensure the component is not cached -->
+  <!-- unloadOnDestroy -->
 
-  <!-- or use unload as a callback to ensure the component is not cached and
+  <!-- or use unloadOnDestroy as a callback to ensure the component is not cached and
        calls the callback immediatly after it is uncached -->
-  unload={() => System.delete(`${location.href}/AsyncComponent.svelte`)}
+  unloadOnDestroy={() => System.delete(`${location.href}/AsyncComponent.svelte`)}
 />
 ```
 
@@ -39,7 +39,7 @@ The example below is using SystemJS module loader which has the ability to 'unlo
 - `loader`: a function which `import()` your component to the `<Loadable>` component.
 - `delay`: minimum delay in `msecs` for showing the `loading slot`. Default: 200
 - `timeout`: time in `msecs` for showing the `timeout slot`.
-- `unload`: true to prevent the component from being cached or a function which will also prevent the component from being cached and will be called immediatly after it is uncached.
+- `unloadOnDestroy`: true to prevent the component from being cached or a function which will also prevent the component from being cached and will be called immediatly after it is uncached.
 
 Any other prop will be passed directly onto the rendered component if the `default` slot is defined:
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Use `unloader` to prevent `Loadable` from caching the component which will cause
 - `loader`: a function which `import()` your component to the `<Loadable>` component.
 - `delay`: minimum delay in `msecs` for showing the `loading slot`. Default: 200
 - `timeout`: time in `msecs` for showing the `timeout slot`.
-- `unloader`: true to prevent the component from being cached or a function which will also prevent the component from being cached and will be called immediatly after it is uncached.
+- `unloader`: `true` to prevent the component from being cached or a `function` which will also prevent the component from being cached after being unmounted and will be called immediately after it is removed from cache.
 
 Any other prop will be passed directly onto the rendered component if the `default` slot is defined:
 


### PR DESCRIPTION
This PR adds the ability to `unload` (or prevent caching) of a component with the additional option of a callback being called when the component is removed from the cache.

As described in the updated readme, an additional prop `unload` was added which is of type `boolean` or `() => void`.  If `true` (default `false`) the component (and `loader`) will be removed from the `LOADED` cache/Map.  If `unload` is a callback it is called immediately after the component is removed from the cache.

_Rationale:_ For components which are rarely used (say settings) or a complex web app where there are a large number of dynamic components (which may utilise considerable memory) it is nice to know the components are not stacking up in a cache.