### PR TITLE
Fix the unloader prop, and suppress load event when un-mounted

### DIFF
--- a/Loadable.svelte
+++ b/Loadable.svelte
@@ -68,7 +68,7 @@
   let state = STATES.INITIALIZED
   let componentProps
   let slots = $$props.$$slots
-  let mounted = true;
+  let mounted = false;
 
   $: {
     let { delay, timeout, loader, component, error, ...rest } = $$props
@@ -131,7 +131,8 @@
     component = LOADED.get(loader)
   } else {
     onMount(() => {
-      Promise.resolve(load()).then(() => {
+      mounted = true;
+      load().then(() => {
         if (mounted) {
           dispatch('load')
         }

--- a/Loadable.svelte
+++ b/Loadable.svelte
@@ -40,11 +40,13 @@
     })
   }
 
-  export async function load(loader) {
+  export async function load(loader, unloader) {
     const componentModule = await loader()
     const component = componentModule.default || componentModule
 
-    LOADED.set(loader, component)
+    if (!unloader){
+      LOADED.set(loader, component)
+    }
     return component
   }
 
@@ -66,6 +68,7 @@
   let state = STATES.INITIALIZED
   let componentProps
   let slots = $$props.$$slots
+  let mounted = true;
 
   $: {
     let { delay, timeout, loader, component, error, ...rest } = $$props
@@ -110,7 +113,7 @@
     }
 
     try {
-      component = await loadComponent(loader)
+      component = await loadComponent(loader, unloader)
       state = STATES.SUCCESS
     } catch (e) {
       state = STATES.ERROR
@@ -127,15 +130,17 @@
     state = STATES.SUCCESS
     component = LOADED.get(loader)
   } else {
-    onMount(async () => {
-      await load()
-      dispatch('load')
-      if (unloader) {
-        return () => {
-          LOADED.delete(loader)
-          if (typeof unloader === 'function') {
-            unloader()
-          }
+    onMount(() => {
+      Promise.resolve(load()).then(() => {
+        if (mounted) {
+          dispatch('load')
+        }
+      })
+
+      return () => {
+        mounted = false;
+        if (typeof unloader === 'function') {
+          unloader()
         }
       }
     })


### PR DESCRIPTION
Fixes: https://github.com/kaisermann/svelte-loadable/issues/39

> If you conditionally render a instance, and then unMount it before the loading finishes, the now-unmounted instance will still fire the load event.
> 
> I'm not sure if it's correct that Svelte even acknowledge events from an unmounted component, but regardless it seems like this component should track when it's been removed, and suppress the event.
> 
> Also, the onMount function being async prevents the teardown callback from ever firing, which prevents the unloader behavior from working.